### PR TITLE
Added support for ctags, etags, sync-token, multi-status 404's, propFind/Patch request building

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.4.1",
-        "sabre/dav": "~1.9.0alpha1",
-        "sabre/http": "dev-master as 2.0.0alpha6"
+        "sabre/dav": "~2.0"
     },
     "require-dev" : {
         "phpunit/phpunit": "3.7.*"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.4.1",
-        "sabre/dav": "~2.0"
+        "sabre/dav": "~2.0.5"
     },
     "require-dev" : {
         "phpunit/phpunit": "3.7.*"

--- a/lib/Sabre/DAVClient/Adapter/CardDAVAdapter.php
+++ b/lib/Sabre/DAVClient/Adapter/CardDAVAdapter.php
@@ -2,7 +2,8 @@
 
 namespace Sabre\DAVClient\Adapter;
 
-use Sabre\HTTP,
+use Sabre,
+    Sabre\HTTP,
     Sabre\DAVClient\ClarkNotation\CardDAV,
     Sabre\DAVClient\ClarkNotation\DAV,
     Sabre\DAVClient\Client,
@@ -86,6 +87,54 @@ class CardDAVAdapter
         }
 
         return new Sync\SyncCollection($syncToken, $responses);
+    }
+
+    /**
+     * Returns a valid and unused vCard id
+     *
+     * @return string $id valid vCard id
+     */
+    public function generateVCardID($uri)
+    {
+        $id = null;
+
+        $chars = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'A', 'B', 'C', 'D', 'E', 'F'];
+
+        for ($i = 0; $i <= 25; $i++) {
+            if ($i == 8 || $i == 17) {
+                $id .= '-';
+            } else {
+                $id .= $chars[mt_rand(0, (count($chars) - 1))];
+            }
+        }
+
+        $response = $this->client->send(new HTTP\Request('GET', $uri . $id));
+
+        switch ($response->getStatus()) {
+            case 200:
+                // id is not unique, try again
+                $id = $this->generateVCardID($uri);
+
+                break;
+            case 404:
+                // do nothing, id is unique
+
+                break;
+            default:
+                throw new \Exception('Unexpected HTTP ' . $response->getStatus() . ' when generating new VCard ID.');
+        }
+
+        return $id;
+    }
+
+    /**
+     * Returns a valid and unused vCard uri
+     *
+     * @return string $uri valid vCard uri
+     */
+    public function generateVCardUri($uri)
+    {
+        return $uri . $this->generateVCardID($uri);
     }
 
     public function parseMultiStatusSyncToken($body) {

--- a/lib/Sabre/DAVClient/Adapter/CardDAVAdapter.php
+++ b/lib/Sabre/DAVClient/Adapter/CardDAVAdapter.php
@@ -8,9 +8,7 @@ use Sabre,
     Sabre\DAVClient\ClarkNotation\DAV,
     Sabre\DAVClient\Client,
     Sabre\DAVClient\RequestBuilder,
-    Sabre\DAVClient\Sync,
-    Sabre\DAV\Property\ResponseList,
-    Sabre\DAV\XMLUtil;
+    Sabre\DAVClient\Sync;
 
 class CardDAVAdapter
 {
@@ -143,17 +141,7 @@ class CardDAVAdapter
      */
     public function generateVCardID($uri)
     {
-        $id = null;
-
-        $chars = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'A', 'B', 'C', 'D', 'E', 'F'];
-
-        for ($i = 0; $i <= 25; $i++) {
-            if ($i == 8 || $i == 17) {
-                $id .= '-';
-            } else {
-                $id .= $chars[mt_rand(0, (count($chars) - 1))];
-            }
-        }
+        $id = Sabre\DAV\UUIDUtil::getUUID();
 
         $response = $this->client->send(new HTTP\Request('GET', $uri . $id));
 
@@ -186,7 +174,7 @@ class CardDAVAdapter
 
     public function parseMultiStatusSyncToken($body) {
         try {
-            $dom = XMLUtil::loadDOMDocument($body);
+            $dom = Sabre\DAV\XMLUtil::loadDOMDocument($body);
         } catch (Exception\BadRequest $e) {
             throw new \InvalidArgumentException('The body passed to parseMultiStatusSyncToken could not be parsed. Is it really xml?');
         }

--- a/lib/Sabre/DAVClient/Adapter/CardDAVAdapter.php
+++ b/lib/Sabre/DAVClient/Adapter/CardDAVAdapter.php
@@ -4,7 +4,9 @@ namespace Sabre\DAVClient\Adapter;
 
 use Sabre\HTTP,
     Sabre\DAVClient\Client,
-    Sabre\DAVClient\RequestBuilder;
+    Sabre\DAVClient\RequestBuilder,
+    Sabre\DAV\Property\ResponseList,
+    Sabre\DAV\XMLUtil;
 
 class CardDAVAdapter
 {
@@ -24,6 +26,43 @@ class CardDAVAdapter
         return $this->client->send($request);
     }
 
+    public function getCTags($uri)
+    {
+        $ctags = $this->client->propFind($uri, ['{DAV:}getctag'], 1);
+
+        $ctags = array_map(
+            function ($ctag) {
+                return $ctag['{DAV:}getctag'];
+            },
+            $ctags
+        );
+
+        return $ctags;
+    }
+
+    public function getETags($uri)
+    {
+        $etags = $this->client->propFind($uri, ['{DAV:}getetag'], 1);
+
+        array_shift($etags); // first result references the address book
+
+        $etags = array_map(
+            function ($etag) {
+                return $etag['{DAV:}getetag'];
+            },
+            $etags
+        );
+
+        return $etags;
+    }
+
+    public function getSyncToken($uri)
+    {
+        $sync_token = $this->client->propFind($uri, ['{DAV:}sync-token'], 1);
+
+        return $sync_token[$uri]['{DAV:}sync-token'];
+    }
+
     public function syncCollectionReport($uri, $sync_token = null, $sync_level = 1)
     {
         $builder = new RequestBuilder\SyncCollectionReportRequestBuilder($uri, $sync_token, $sync_level);
@@ -31,5 +70,21 @@ class CardDAVAdapter
         $request = $builder->build();
 
         return $this->client->send($request);
+    }
+
+    public function parseMultiStatusSyncToken($body) {
+        try {
+            $dom = XMLUtil::loadDOMDocument($body);
+        } catch (Exception\BadRequest $e) {
+            throw new \InvalidArgumentException('The body passed to parseMultiStatusSyncToken could not be parsed. Is it really xml?');
+        }
+
+        $element = $dom->getElementsByTagNameNS('urn:DAV', 'sync-token');
+
+        if (!$element->length) {
+            throw new \Exception('No sync token found in parseMultiStatusSyncToken');
+        }
+
+        return $element->item(0)->textContent;
     }
 }

--- a/lib/Sabre/DAVClient/Adapter/CardDAVAdapter.php
+++ b/lib/Sabre/DAVClient/Adapter/CardDAVAdapter.php
@@ -30,6 +30,11 @@ class CardDAVAdapter
         return $this->client->send($request);
     }
 
+    public function getCTag($uri)
+    {
+        return current($this->getCTags($uri));
+    }
+
     public function getCTags($uri)
     {
         $ctags = $this->client->propFind($uri, [DAV::CTAG], 1);
@@ -44,11 +49,17 @@ class CardDAVAdapter
         return $ctags;
     }
 
+    public function getETag($uri)
+    {
+        return current($this->getETags($uri));
+    }
+
     public function getETags($uri)
     {
         $etags = $this->client->propFind($uri, [DAV::ETAG], 1);
 
-        array_shift($etags); // first result references the address book
+        // if the uri was for the address book, the first result is the address book, with no properties
+        $etags = array_filter($etags);
 
         $etags = array_map(
             function ($etag) {

--- a/lib/Sabre/DAVClient/ClarkNotation/CardDAV.php
+++ b/lib/Sabre/DAVClient/ClarkNotation/CardDAV.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Sabre\DAVClient\ClarkNotation;
+
+abstract class CardDAV
+{
+    const ADDRESS_DATA = '{urn:ietf:params:xml:ns:carddav}address-data';
+}

--- a/lib/Sabre/DAVClient/ClarkNotation/DAV.php
+++ b/lib/Sabre/DAVClient/ClarkNotation/DAV.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Sabre\DAVClient\ClarkNotation;
+
+abstract class DAV
+{
+    const CTAG = '{DAV:}getctag';
+    const ETAG = '{DAV:}getetag';
+    const SYNC_TOKEN = '{DAV:}sync-token';
+}

--- a/lib/Sabre/DAVClient/Client.php
+++ b/lib/Sabre/DAVClient/Client.php
@@ -133,7 +133,7 @@ class Client extends HTTP\Client
 
         parent::__construct();
 
-        $this->baseUri = $settings['baseUri'];
+        $this->setBaseUri($settings['baseUri']);
 
         if (isset($settings['proxy'])) {
             $this->addCurlSetting(CURLOPT_PROXY, $settings['proxy']);
@@ -385,12 +385,24 @@ class Client extends HTTP\Client
         // If the url starts with a slash, we must calculate the url based off
         // the root of the base url.
         if (strpos($url,'/') === 0) {
-            $parts = parse_url($this->baseUri);
+            $parts = parse_url($this->getBaseUri());
             return $parts['scheme'] . '://' . $parts['host'] . (isset($parts['port'])?':' . $parts['port']:'') . $url;
         }
 
         // Otherwise...
-        return $this->baseUri . $url;
+        return $this->getBaseUri() . $url;
+    }
+
+    public function getBaseUri()
+    {
+        return $this->baseUri;
+    }
+
+    public function setBaseUri($uri)
+    {
+        $this->baseUri = $uri;
+
+        return $uri;
     }
 
     /**

--- a/lib/Sabre/DAVClient/Client.php
+++ b/lib/Sabre/DAVClient/Client.php
@@ -509,7 +509,13 @@ class Client extends HTTP\Client
         $result = [];
 
         foreach ($responses->getResponses() as $response) {
-            $result[$response->getHref()] = $response->getResponseProperties();
+            $properties = $response->getResponseProperties();
+
+            if ($response->getHttpStatus()) {
+                $properties += [$response->getHttpStatus() => []];
+            }
+
+            $result[$response->getHref()] = $properties;
         }
 
         return $result;

--- a/lib/Sabre/DAVClient/Client.php
+++ b/lib/Sabre/DAVClient/Client.php
@@ -236,35 +236,7 @@ class Client extends HTTP\Client
      */
     public function propFind($url, array $properties, $depth = 0)
     {
-        $dom = new \DOMDocument('1.0', 'UTF-8');
-        $dom->formatOutput = true;
-        $root = $dom->createElementNS('DAV:', 'd:propfind');
-        $prop = $dom->createElement('d:prop');
-
-        foreach ($properties as $property) {
-            list(
-                $namespace,
-                $elementName
-            ) = XMLUtil::parseClarkNotation($property);
-
-            if ($namespace === 'DAV:') {
-                $element = $dom->createElement('d:'.$elementName);
-            } else {
-                $element = $dom->createElementNS($namespace, 'x:'.$elementName);
-            }
-
-            $prop->appendChild( $element );
-        }
-
-        $dom->appendChild($root)->appendChild( $prop );
-        $body = $dom->saveXML();
-
-        $url = $this->getAbsoluteUrl($url);
-
-        $request = new HTTP\Request('PROPFIND', $url, [
-            'Depth' => $depth,
-            'Content-Type' => 'application/xml'
-        ], $body);
+        $request = (new RequestBuilder\PropFindRequestBuilder($url, $properties, $depth))->build();
 
         $response = $this->send($request);
 
@@ -299,60 +271,13 @@ class Client extends HTTP\Client
      *
      * @param string $url
      * @param array $properties
-     * @return void
+     * @return Response
      */
     public function propPatch($url, array $properties)
     {
-        $dom = new \DOMDocument('1.0', 'UTF-8');
-        $dom->formatOutput = true;
-        $root = $dom->createElementNS('DAV:', 'd:propertyupdate');
+        $request = (new RequestBuilder\PropPathRequestBuilder($url, $properties))->build();
 
-        foreach ($properties as $propName => $propValue) {
-            list(
-                $namespace,
-                $elementName
-            ) = XMLUtil::parseClarkNotation($propName);
-
-            if ($propValue === null) {
-                $remove = $dom->createElement('d:remove');
-                $prop = $dom->createElement('d:prop');
-
-                if ($namespace === 'DAV:') {
-                    $element = $dom->createElement('d:'.$elementName);
-                } else {
-                    $element = $dom->createElementNS($namespace, 'x:'.$elementName);
-                }
-
-                $root->appendChild( $remove )->appendChild( $prop )->appendChild( $element );
-            } else {
-
-                $set = $dom->createElement('d:set');
-                $prop = $dom->createElement('d:prop');
-
-                if ($namespace === 'DAV:') {
-                    $element = $dom->createElement('d:'.$elementName);
-                } else {
-                    $element = $dom->createElementNS($namespace, 'x:'.$elementName);
-                }
-
-                if ( $propValue instanceof Property ) {
-                    $propValue->serialize( new Server, $element );
-                } else {
-                    $element->nodeValue = htmlspecialchars($propValue, ENT_NOQUOTES, 'UTF-8');
-                }
-
-                $root->appendChild( $set )->appendChild( $prop )->appendChild( $element );
-            }
-        }
-
-        $dom->appendChild($root);
-        $body = $dom->saveXML();
-
-        $url = $this->getAbsoluteUrl($url);
-        $request = new HTTP\Request('PROPPATCH', $url, [
-            'Content-Type' => 'application/xml',
-        ], $body);
-        $this->send($request);
+        return $this->send($request);
     }
 
     /**

--- a/lib/Sabre/DAVClient/RequestBuilder/PropFindRequestBuilder.php
+++ b/lib/Sabre/DAVClient/RequestBuilder/PropFindRequestBuilder.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Sabre\DAVClient\RequestBuilder;
+
+use Sabre\HTTP,
+    Sabre\DAV\XMLUtil;
+
+class PropFindRequestBuilder implements RequestBuilderInterface
+{
+    protected $depth = 0;
+
+    protected $headers = ['Content-Type' => 'text/xml'];
+
+    protected $method = 'PROPFIND';
+
+    protected $properties;
+
+    protected $url;
+
+    public function __construct($url, array $properties, $depth = 0)
+    {
+        $this->url = $url;
+        $this->properties = $properties;
+        $this->depth = $depth;
+    }
+
+    public function build()
+    {
+        $headers = array_merge($this->headers, ['Depth' => $this->depth]);
+
+        return new HTTP\Request($this->method, $this->url, $headers, $this->writeXML());
+    }
+
+    protected function writeXML()
+    {
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom->formatOutput = true;
+        $root = $dom->createElementNS('DAV:', 'd:propfind');
+        $prop = $dom->createElement('d:prop');
+
+        foreach ($this->properties as $property) {
+            list($namespace, $elementName) = XMLUtil::parseClarkNotation($property);
+
+            if ($namespace === 'DAV:') {
+                $element = $dom->createElement('d:' . $elementName);
+            } else {
+                $element = $dom->createElementNS($namespace, 'x:' . $elementName);
+            }
+
+            $prop->appendChild($element);
+        }
+
+        $dom->appendChild($root)->appendChild($prop);
+
+        return $dom->saveXML();
+    }
+}

--- a/lib/Sabre/DAVClient/RequestBuilder/PropPatchRequestBuilder.php
+++ b/lib/Sabre/DAVClient/RequestBuilder/PropPatchRequestBuilder.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Sabre\DAVClient\RequestBuilder;
+
+use Sabre\HTTP,
+    Sabre\DAV\Property,
+    Sabre\DAV\XMLUtil;
+
+class PropPatchRequestBuilder implements RequestBuilderInterface
+{
+    protected $headers = ['Content-Type' => 'text/xml'];
+
+    protected $method = 'PROPPATCH';
+
+    protected $properties;
+
+    protected $url;
+
+    public function __construct($url, array $properties)
+    {
+        $this->url = $url;
+        $this->properties = $properties;
+    }
+
+    public function build()
+    {
+        return new HTTP\Request($this->method, $this->url, $this->headers, $this->writeXML());
+    }
+
+    protected function writeXML()
+    {
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom->formatOutput = true;
+        $root = $dom->createElementNS('DAV:', 'd:propertyupdate');
+
+        foreach ($this->properties as $propName => $propValue) {
+            list($namespace, $elementName) = XMLUtil::parseClarkNotation($propName);
+
+            if ($propValue === null) {
+                $remove = $dom->createElement('d:remove');
+                $prop = $dom->createElement('d:prop');
+
+                if ($namespace === 'DAV:') {
+                    $element = $dom->createElement('d:' . $elementName);
+                } else {
+                    $element = $dom->createElementNS($namespace, 'x:' . $elementName);
+                }
+
+                $root->appendChild($remove)->appendChild($prop)->appendChild($element);
+            } else {
+                $set = $dom->createElement('d:set');
+                $prop = $dom->createElement('d:prop');
+
+                if ($namespace === 'DAV:') {
+                    $element = $dom->createElement('d:' . $elementName);
+                } else {
+                    $element = $dom->createElementNS($namespace, 'x:' . $elementName);
+                }
+
+                if ($propValue instanceof Property) {
+                    $propValue->serialize( new Server, $element );
+                } else {
+                    $element->nodeValue = htmlspecialchars($propValue, ENT_NOQUOTES, 'UTF-8');
+                }
+
+                $root->appendChild($set)->appendChild($prop)->appendChild($element);
+            }
+        }
+
+        $dom->appendChild($root);
+
+        return $dom->saveXML();
+    }
+}

--- a/lib/Sabre/DAVClient/RequestBuilder/SyncCollectionRequestBuilder.php
+++ b/lib/Sabre/DAVClient/RequestBuilder/SyncCollectionRequestBuilder.php
@@ -4,7 +4,7 @@ namespace Sabre\DAVClient\RequestBuilder;
 
 use Sabre\HTTP;
 
-class SyncCollectionReportRequestBuilder implements RequestBuilderInterface
+class SyncCollectionRequestBuilder implements RequestBuilderInterface
 {
     protected $sync_token;
 
@@ -34,10 +34,12 @@ class SyncCollectionReportRequestBuilder implements RequestBuilderInterface
         $xml->startDocument('1.0', 'utf-8');
             $xml->startElement('d:sync-collection');
                 $xml->writeAttribute('xmlns:d', 'DAV:');
+                $xml->writeAttribute('xmlns:a', 'urn:ietf:params:xml:ns:carddav');
                 $xml->writeElement('d:sync-token', $this->sync_token);
                 $xml->writeElement('d:sync-level', $this->sync_level);
                 $xml->startElement('d:prop');
                     $xml->writeElement('d:getetag');
+                    $xml->writeElement('a:address-data');
                 $xml->endElement();
             $xml->endElement();
         $xml->endDocument();

--- a/lib/Sabre/DAVClient/Sync/SyncCollection.php
+++ b/lib/Sabre/DAVClient/Sync/SyncCollection.php
@@ -23,9 +23,7 @@ class SyncCollection
         foreach ($responses as $uri => $response) {
             if (array_key_exists(200, $response)) {
                 $this->modified[] = new VCardReference($uri, $response[200]);
-            }
-
-            if (array_key_exists(404, $response)) {
+            } elseif (array_key_exists(404, $response)) {
                 $this->deleted[] = new VCardReference($uri, $response[404]);
             }
         }

--- a/lib/Sabre/DAVClient/Sync/SyncCollection.php
+++ b/lib/Sabre/DAVClient/Sync/SyncCollection.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Sabre\DAVClient\Sync;
+
+use Sabre\HTTP,
+    Sabre\DAVClient\Client,
+    Sabre\DAVClient\RequestBuilder,
+    Sabre\DAV\Property\ResponseList,
+    Sabre\DAV\XMLUtil;
+
+class SyncCollection
+{
+    protected $modified = [];
+    protected $deleted = [];
+    protected $responses;
+    protected $syncToken;
+
+    public function __construct($syncToken, array $responses)
+    {
+        $this->responses = $responses;
+        $this->syncToken = $syncToken;
+
+        foreach ($responses as $uri => $response) {
+            if (array_key_exists(200, $response)) {
+                $this->modified[] = new VCardReference($uri, $response[200]);
+            }
+
+            if (array_key_exists(404, $response)) {
+                $this->deleted[] = new VCardReference($uri, $response[404]);
+            }
+        }
+    }
+
+    public function getModified()
+    {
+        return $this->modified;
+    }
+
+    public function getDeleted()
+    {
+        return $this->deleted;
+    }
+
+    public function getResponses()
+    {
+        return $this->responses;
+    }
+
+    public function getSyncToken()
+    {
+        return $this->syncToken;
+    }
+}

--- a/lib/Sabre/DAVClient/Sync/VCardReference.php
+++ b/lib/Sabre/DAVClient/Sync/VCardReference.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Sabre\DAVClient\Sync;
+
+use Sabre,
+    Sabre\DAVClient\ClarkNotation\CardDAV,
+    Sabre\DAVClient\ClarkNotation\DAV,
+    Sabre\DAVClient\Client;
+
+class VCardReference
+{
+    protected $uri;
+
+    protected $etag;
+
+    protected $vcard;
+
+    public function __construct($uri, array $properties = [])
+    {
+        $this->uri = $uri;
+
+        if (array_key_exists(CardDAV::ADDRESS_DATA, $properties)) {
+            $this->vcard = Sabre\VObject\Reader::read($properties[CardDAV::ADDRESS_DATA]);
+        }
+
+        if (array_key_exists(DAV::ETAG, $properties)) {
+            $this->etag = $properties[DAV::ETAG];
+        }
+    }
+
+    public function __toString()
+    {
+        return (string) $this->getUri();
+    }
+
+    public function getUri()
+    {
+        return $this->uri;
+    }
+
+    public function getVCard()
+    {
+        return $this->vcard;
+    }
+
+    public function getETag()
+    {
+        return $this->etag;
+    }
+}

--- a/lib/Sabre/DAVClient/Sync/VCardReference.php
+++ b/lib/Sabre/DAVClient/Sync/VCardReference.php
@@ -13,19 +13,14 @@ class VCardReference
 
     protected $etag;
 
+    protected $properties;
+
     protected $vcard;
 
     public function __construct($uri, array $properties = [])
     {
-        $this->uri = $uri;
-
-        if (array_key_exists(CardDAV::ADDRESS_DATA, $properties)) {
-            $this->vcard = Sabre\VObject\Reader::read($properties[CardDAV::ADDRESS_DATA]);
-        }
-
-        if (array_key_exists(DAV::ETAG, $properties)) {
-            $this->etag = $properties[DAV::ETAG];
-        }
+        $this->setUri($uri);
+        $this->setProperties($properties);
     }
 
     public function __toString()
@@ -38,13 +33,61 @@ class VCardReference
         return $this->uri;
     }
 
-    public function getVCard()
+    public function setUri($uri)
     {
-        return $this->vcard;
+        $this->uri = $uri;
+
+        return $this;
     }
 
     public function getETag()
     {
         return $this->etag;
+    }
+
+    public function setETag($etag)
+    {
+        $this->etag = $etag;
+
+        return $this;
+    }
+
+    public function getProperties()
+    {
+        return $this->properties;
+    }
+
+    public function setProperties($properties)
+    {
+        $this->properties = $properties;
+
+        $this->parseProperties($properties);
+
+        return $this;
+    }
+
+    public function getVCard()
+    {
+        return $this->vcard;
+    }
+
+    public function setVCard($vcard)
+    {
+        $this->vcard = $vcard;
+
+        return $this;
+    }
+
+    protected function parseProperties()
+    {
+        if (array_key_exists(CardDAV::ADDRESS_DATA, $this->properties)) {
+            $this->setVCard(Sabre\VObject\Reader::read($this->properties[CardDAV::ADDRESS_DATA]));
+        }
+
+        if (array_key_exists(DAV::ETAG, $this->properties)) {
+            $this->setETag($this->properties[DAV::ETAG]);
+        }
+
+        return $this;
     }
 }


### PR DESCRIPTION
- Added support for ctags
- Added support for etags
- Added support for sync-token requests
- Added 404's into multi-status responses
- Moved propFind and propPatch logic out to RequestBuilders, useful when you want the response object or to process the multi-status yourself.
